### PR TITLE
Optimizing escape function

### DIFF
--- a/json2latex/escape.py
+++ b/json2latex/escape.py
@@ -1,3 +1,22 @@
+_replacements = {
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\^{}",
+    "\\": r"\textbackslash{}",
+    "\n": "\\newline%\n",
+    "-": r"{-}",
+    "\xA0": "~",  # Non-breaking space
+    "[": r"{[}",
+    "]": r"{]}",
+}
+_replacement_lookup = str.maketrans(_replacements)
+
 def escape(string):
     """
     Replace special characters with their equivalent LaTeX macros.
@@ -8,24 +27,4 @@ def escape(string):
     Returns:
         str: The string with special characters replaced with macros.
     """
-    replacements = {
-        "&": r"\&",
-        "%": r"\%",
-        "$": r"\$",
-        "#": r"\#",
-        "_": r"\_",
-        "{": r"\{",
-        "}": r"\}",
-        "~": r"\textasciitilde{}",
-        "^": r"\^{}",
-        "\\": r"\textbackslash{}",
-        "\n": "\\newline%\n",
-        "-": r"{-}",
-        "\xA0": "~",  # Non-breaking space
-        "[": r"{[}",
-        "]": r"{]}",
-    }
-    escaped = ""
-    for char in string:
-        escaped += replacements.get(char, char)
-    return escaped
+    return string.translate(_replacement_lookup)

--- a/json2latex/escape.py
+++ b/json2latex/escape.py
@@ -17,6 +17,7 @@ _replacements = {
 }
 _replacement_lookup = str.maketrans(_replacements)
 
+
 def escape(string):
     """
     Replace special characters with their equivalent LaTeX macros.


### PR DESCRIPTION
I simplified the `escape` function using Python's builtin `str.translate` to do all of the legwork.  My tests on 1 million random strings show that this makes it approximately 67% faster to evaluate, and the output values are unchanged.

You can see this for yourself by running the following script (`time_escape.py`) on both versions
```python
from json2latex.escape import escape
from string import ascii_letters, digits
from numpy.random import RandomState
from timeit import default_timer
from hashlib import md5

# Characters that need to be escaped for LaTeX.
escape_chars = "&%$#_{}~^\\\n-\xA0[]"
# Full alphabet of characters to use in our trials.
alphabet = list(ascii_letters + digits + escape_chars)

# RNG seed
seed = 901
random_state = RandomState(seed)
# How many random trials to do within our timing.
n_trials = 1000000
# Largest possible string to generate in a trial.
size_max = 50

# Set up the strings we need to escape ahead of time so we only measure the time
# spent escaping them.
strings_to_escape = []
for _ in range(n_trials):
    # Pick a random number of characters for this string.
    size = random_state.randint(0, size_max+1)
    # Create a random string.
    s = "".join(random_state.choice(alphabet, size))

    # Save the string.
    strings_to_escape.append(s)

# Measure the time it takes to escape all of these strings.
t_start = default_timer()
for s in strings_to_escape:
    s_esc = escape(s)
t_end = default_timer()

# Display the elapsed time.
print("Duration of", n_trials, "trials is", t_end-t_start, "seconds")

# Re-run the loop we timed, but compute an MD5 checksum of the concatenated
# string so we can confirm versions of the code produce the same output.
str_hash = md5()
for s in strings_to_escape:
    s_esc = escape(s)
    str_hash.update(s_esc.encode())

print("MD5 checksum is", str_hash.hexdigest())
```

Running this on the original version
```bash
git clone https://github.com/dwysocki/json2latex.git

cd json2latex
git checkout d0c27e4232bba1ddf6465f96204e9799e4ea54f0
pip install .
cd -

python time_escape.py
```

```
Duration of 1000000 trials is 2.469152439996833 seconds
MD5 checksum is 7d25a0130ec23286971684e95146eae1
```

Using the updated version
```bash
cd json2latex
git checkout f3a0cf1da6a1cef222adea016f7dc15bc275ce37
pip install .
cd -

python time_escape.py
```

```
Duration of 1000000 trials is 1.4987323099994683 seconds
MD5 checksum is 7d25a0130ec23286971684e95146eae1
```