### PR TITLE
Add latex warning for undefined queries

### DIFF
--- a/json2latex/python2latex.py
+++ b/json2latex/python2latex.py
@@ -127,7 +127,7 @@ class python2latex:
             self._tex += "\\else%"
             self._nl(3)
 
-        self._tex += "\PackageWarning{json2latex}{Undefined query `#1'}%"
+        self._tex += "\\PackageWarning{json2latex}{Undefined query `#1'}%"
         self._def_out(ind, "??")
         self._nl(2)
 

--- a/json2latex/python2latex.py
+++ b/json2latex/python2latex.py
@@ -127,6 +127,7 @@ class python2latex:
             self._tex += "\\else%"
             self._nl(3)
 
+        self._tex += "\PackageWarning{json2latex}{Undefined query `#1'}%"
         self._def_out(ind, "??")
         self._nl(2)
 


### PR DESCRIPTION
Redefines the final `else` block to include a warning, keeping the `??` output as before:
```
\else%
  \PackageWarning{json2latex}{Undefined query `#1'}%
  \def\resultsRE@out{%
??}%
```

Example latex log entry:
```
Package json2latex Warning: Undefined query `numLinConstraints' on input line 236.
```